### PR TITLE
Avoid detecting SCSS files as CSS

### DIFF
--- a/CSScomb.py
+++ b/CSScomb.py
@@ -107,14 +107,14 @@ class CssCombCommand(sublime_plugin.TextCommand):
         return self.view.file_name() == None and self.is_plaintext() == True
 
     def is_plaintext(self):
-        return self.view.settings().get('syntax').endswith('Plain text.tmLanguage')
+        return self.view.settings().get('syntax').endswith('/Plain text.tmLanguage')
 
     def is_css(self):
-        return self.view.settings().get('syntax').endswith('CSS.tmLanguage')
+        return self.view.settings().get('syntax').endswith('/CSS.tmLanguage')
 
     def is_scss(self):
-        return self.view.settings().get('syntax').endswith('SCSS.tmLanguage')
+        return self.view.settings().get('syntax').endswith('/SCSS.tmLanguage')
 
     def is_less(self):
-        return self.view.settings().get('syntax').endswith('LESS.tmLanguage')
+        return self.view.settings().get('syntax').endswith('/LESS.tmLanguage')
 


### PR DESCRIPTION
Hey there.

I was having the same issues as #7 so i checked what was the problem and here is what i found:
The is_css method returned true even for synthax like `Packages/SCSS/SCSS.tmLanguage` (in my case) because of the endswith.
The fix i applyed is simple as you can see and works for me but i have never written any python before, so there may be a better way to do this.

Hope this helps ;)
