### PR TITLE
Path to README and settings, keymap correction

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -30,7 +30,7 @@
                             {
                                 "command": "open_file",
                                 "args": {
-                                    "file": "${packages}/CSScomb JS/README.md"
+                                    "file": "${packages}/CSScomb/README.md"
                                 },
                                 "caption": "README"
                             },
@@ -38,7 +38,7 @@
                             {
                                 "command": "open_file",
                                 "args": {
-                                    "file": "${packages}/CSScomb JS/CSScomb JS.sublime-settings"
+                                    "file": "${packages}/CSScomb/CSScomb JS.sublime-settings"
                                 },
                                 "caption": "Settings – Default"
                             },
@@ -53,7 +53,7 @@
                             {
                                 "command": "open_file",
                                 "args": {
-                                    "file": "${packages}/CSScomb JS/Default.sublime-keymap"
+                                    "file": "${packages}/CSScomb/Default.sublime-keymap"
                                 },
                                 "caption": "Key Bindings – Default"
                             },


### PR DESCRIPTION
The path was pointing to `/CSScomb JS/` instead of the installed path `/CSScomb/`.
