### PR TITLE
Restrict the default key binding to when a CSS syntax is active

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1,3 +1,7 @@
 [
-    { "keys": ["ctrl+shift+c"], "command": "css_comb" }
+    { "keys": ["ctrl+shift+c"], "command": "css_comb", "context":
+      [
+        { "key": "selector", "operator": "regex_match", "operand": "(text\\.plain|source\\.(css|scss|less))" }
+      ]
+    }
 ]


### PR DESCRIPTION
This PR is intended as a complement to https://github.com/csscomb/sublime-csscomb/pull/32, which I think is a very solid change.

Currently, the CSScomb command is a no-op unless an appropriate syntax is detected. This PR makes the key binding do the same syntax-checking that the CSScomb command does in #32. This prevents the command from interfering with other plugins that may use the same keyboard shortcut in other contexts. For example, I use SublimeGit, which uses Ctrl+Shift+C for its "Git Commit Amend" command, but only in its SublimeGit Status context.
