### PR TITLE
Fix loading of .csscomb.json

### DIFF
--- a/CSScomb.py
+++ b/CSScomb.py
@@ -38,8 +38,9 @@ class CssCombCommand(sublime_plugin.TextCommand):
 
     def comb(self, css, syntax, config):
         config = json.dumps(config)
+        folder = os.path.dirname(self.view.file_name())
         try:
-            p = Popen(['node', COMB_PATH] + [syntax, config],
+            p = Popen(['node', COMB_PATH] + [syntax, config, folder],
                 stdout=PIPE, stdin=PIPE, stderr=PIPE,
                 env=self.get_env(), shell=self.is_windows())
         except OSError:

--- a/csscomb.js
+++ b/csscomb.js
@@ -19,6 +19,8 @@ process.stdin.on('end', function () {
         config = null;
     }
 
+    process.chdir(process.argv[4]);
+
     config = Comb.getCustomConfig() ||
         config ||
         Comb.getConfig('csscomb');


### PR DESCRIPTION
**CSScomb** used process directory to resolve path to custom `.csscomb.json`. Now script for running **CSScomb** _chdir_'s to file directory before resolving custom config.