### PR TITLE
Fix CSScomb when Sass tmLanguage installed

### DIFF
--- a/CSScomb.py
+++ b/CSScomb.py
@@ -74,6 +74,8 @@ class CssCombCommand(sublime_plugin.TextCommand):
             return 'css'
         if self.is_scss():
             return 'scss'
+        if self.is_sass():
+            return 'sass'
         if self.is_less():
             return 'less'
         if self.is_unsaved_buffer_without_syntax():
@@ -103,7 +105,10 @@ class CssCombCommand(sublime_plugin.TextCommand):
         return self.view.scope_name(0).startswith('source.css')
 
     def is_scss(self):
-        return self.view.scope_name(0).startswith('source.scss')
+        return self.view.scope_name(0).startswith('source.scss') or self.view.file_name().endswith('.scss')
+
+    def is_sass(self):
+        return self.view.scope_name(0).startswith('source.sass')
 
     def is_less(self):
         return self.view.scope_name(0).startswith('source.less')


### PR DESCRIPTION
CSScomb was not running when Sass tmLanguage was used for syntax highlighting.

Fixes #18